### PR TITLE
Address and phone number features

### DIFF
--- a/index.js
+++ b/index.js
@@ -1191,3 +1191,16 @@ is.zipCode = function(str) {
   return zip.test(str);
 };
 is.zip = is.zipCode;
+
+/**
+ * Test if a string contains a US phone number
+ * @param {String} the string to search
+ * @return true if str contains a phone number, false otherwise.
+ */
+ is.phoneNumber = function(str){
+   if (!is.string(str))
+    return false;
+   var nums = /(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:(\(?)(?:(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]‌​)\s*)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\)?)\s*(?:[.-]\s*)?)?([2-9]1[02-‌​9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})/g;
+   return nums.test(str);
+ };
+ is.phone = is.phoneNumber;

--- a/index.js
+++ b/index.js
@@ -333,7 +333,7 @@ is.objectInstanceOf = function(objInst, objType) {
         return false;
     }
 };
-is.instOf = is.instanceOf = is.objInstOf = is.objectInstanceOf
+is.instOf = is.instanceOf = is.objInstOf = is.objectInstanceOf;
 
 /**
  * Test if 'value' is a type of 'type'.
@@ -1156,3 +1156,38 @@ is.visaElectronCardNumber = function(str) {
 };
 
 is.visaElectron = is.visaElectronCard = is.visaElectronCardNumber;
+
+// US Address components
+/**********************************
+***Definitely a work in progress***
+**********************************/
+/**
+ * Test if a string contains a US street address
+ * @param {String} the string to search
+ * @return true if an address is present, false otherwise
+ */
+is.streetAddress = function(str) {
+  if (!is.str(str))
+      return false;
+
+  var regex = /\b\d+[\s](?:[A-Za-z0-9.-]+[\s]+)+\b(ALLEY|ALY|AVENUE|AVE|BEND|BND|BLUFFS?|BLFS?|BOULEVARD|BLVD|BRANCH|BR|CENTERS?|CTRS?|CIRCLES?|CIRS?|CLIFFS?|CLFS?|COURTS?|CTS?|COVES?|CVS?|CREEK|CRK|CRESCENT|CRES|CREST|CRST|CROSSING|XING|DRIVES?|DRS?|EXPRESSWAY|EXPY|FREEWAY|FWY|HEIGHTS|HTS|HIGHWAY|HWY|HILLS?|HLS?|LANE|LN|LOOP|MANORS?|MNRS?|MOTORWAY|MTWY|MOUNT|MT|PARKS?|PARKWAYS?|PKWY|PASS|PLACE|PL|PLAZA|PLZ|POINTS?|PTS?|RIDGES?|RDGS?|ROADS?|RDS?|ROUTE|RTE?|SHOALS?|SHLS?|SHORES?|SHRS?|SPRINGS?|SPGS?|SPURS?|STREETS?|STS?|SUMMIT|SMT|TERRACE|TER|THROUGHWAY|TRWY|TRAFFICWAY|TRFY|TRAIL|TRL|TURNPIKE|TPKE|VALLEYS?|VLYS?|WAYS?)+(?:[\.\-\s\,]?)*((APARTMENT|APT|APPT|#|NUMBER|NUM|FLOOR|FL|\s)?(\d)*)\b/ig;
+
+  return regex.test(str);
+};
+is.street = is.address = is.streetAddress;
+
+/**
+ * Test if a string resembles a US Zip code,
+ * no regular expression will be perfect for this,
+ * as there are many numbers that aren't valid zip codes
+ * @param {String || Number} the string or number literal to test
+ * @return true if zipcode like, false otherwise
+ */
+is.zipCode = function(str) {
+  if (is.undefined(str) || !(is.string(str) || is.number(str)))
+    return false;
+
+  var zip = /^\d{5}(?:-\d{4})?$/;
+  return zip.test(str);
+};
+is.zip = is.zipCode;

--- a/tests.js
+++ b/tests.js
@@ -1376,6 +1376,7 @@ describe('is.phoneNumber', function(){
     assert.equal(false, is.phoneNumber());
     assert.equal(false, is.phoneNumber(23897498729387));
     assert.equal(false, is.phoneNumber('something with a 213219 number in it'));
+    assert.equal(false, is.phoneNumber('something with a 123,456,7890 number in it'));
 
     assert.equal(true, is.phoneNumber('my number is 123.555.5767'));
     assert.equal(true, is.phoneNumber('my number is 1 123-555-5767'));

--- a/tests.js
+++ b/tests.js
@@ -1370,3 +1370,26 @@ describe('is.zipCode', function(){
     assert.equal(true, is.zipCode('12345-6789'));
   });
 });
+
+describe('is.phoneNumber', function(){
+  it('should return true for a string containing a US phone number', function(){
+    assert.equal(false, is.phoneNumber());
+    assert.equal(false, is.phoneNumber(23897498729387));
+    assert.equal(false, is.phoneNumber('something with a 213219 number in it'));
+
+    assert.equal(true, is.phoneNumber('my number is 123.555.5767'));
+    assert.equal(true, is.phoneNumber('my number is 1 123-555-5767'));
+    assert.equal(true, is.phoneNumber('my number is (123) 555-5767'));
+    assert.equal(true, is.phoneNumber('my number is (123) 555.5767'));
+    assert.equal(true, is.phoneNumber('my number is 123 555 5767'));
+    assert.equal(true, is.phoneNumber('my number is 123 555 5767 and here\'s some more text'));
+    assert.equal(true, is.phoneNumber('my number is (123) 555 5767 and here\'s some more text'));
+    assert.equal(true, is.phoneNumber('my number is 123-555-5767 and here\'s some more text'));
+    assert.equal(true, is.phoneNumber('my number is 1.123.555.5767 and here\'s some more text'));
+    assert.equal(true, is.phoneNumber('my number is 1-123-555-5767 and here\'s some more text'));
+    assert.equal(true, is.phoneNumber('my number is 1 (123) 555-5767 and here\'s some more text'));
+    assert.equal(true, is.phoneNumber('my number is 1 (123) 555 5767 and here\'s some more text'));
+    assert.equal(true, is.phoneNumber('my number is 1 (123) 555                               5767 and here\'s some more text'));
+    assert.equal(true, is.phoneNumber('my number is 1 (123) 555 \n5767 and here\'s some more text'));
+  });
+});

--- a/tests.js
+++ b/tests.js
@@ -1334,3 +1334,39 @@ describe('is.hostAddress', function() {
     });
 });
 
+describe('is.streetAddress', function(){
+  it('should return true for a string containing a street address', function(){
+    assert.equal(false, is.streetAddress());
+    assert.equal(false, is.streetAddress(null));
+    assert.equal(false, is.streetAddress(-1));
+    assert.equal(false, is.streetAddress('123'));
+    assert.equal(false, is.streetAddress(undefined));
+    assert.equal(false, is.streetAddress('192.168.0.1'));
+    assert.equal(false, is.streetAddress('some unrelated string, with nothing in common with any other strings in the room. \n Poor little guy'));
+    assert.equal(false, is.streetAddress('This string talks about money, and 55 dollars is nothing to scoff at, but shouldn\'t trigger a false positive.'));
+    assert.equal(false, is.streetAddress('This string doesn\'t use money, but it does use numbers like 23 is a good number, so is 999 or 234,432.'));
+
+    assert.equal(true, is.streetAddress('55 Main Street.'));
+    assert.equal(true, is.streetAddress('1999 Pullman Ave. Apt. 322'));
+    assert.equal(true, is.streetAddress('This is a long string with newline characters, \nthis should still capture an address like 123 Sesame Street.'));
+    assert.equal(true, is.streetAddress('I know I should\'t really have to do this,' +
+                'but template strings are an ES6 feature. If you want to submit ideas for this project,' +
+                'you should write to 89 Some Place, #33 San Francisco, CA 94130. Or, don\'t, the choice is up to you.'));
+  });
+});
+
+describe('is.zipCode', function(){
+  it('should return true for a string or number resembling a US zipcode', function(){
+    assert.equal(false, is.zipCode());
+    assert.equal(false, is.zipCode(1234));
+    assert.equal(false, is.zipCode('555-555-5555'));
+    assert.equal(false, is.zipCode(123456));
+    assert.equal(false, is.zipCode('10293-564372'));
+    assert.equal(false, is.zipCode({something: 'is wrong here'}));
+    assert.equal(false, is.zipCode(['something', 'is wrong here']));
+
+    assert.equal(true, is.zipCode(12345));
+    assert.equal(true, is.zipCode('99999'));
+    assert.equal(true, is.zipCode('12345-6789'));
+  });
+});


### PR DESCRIPTION
Adds a couple methods to check for the most common patterns for US street address, zip codes, and telephone numbers. 
 The street address method does not look for a city/state, rather it looks for common street address patterns such as `123 main st` or `8 Some Place Apt. 333`

Zip code method is pretty standard, looks for five digits in a row, optionally followed by a hyphen (-) and four more digits.

Phone number method looks for standard US telephone numbers, it will check for the optional country code, followed by an optional area code, followed by the primary 7 digits separated by a hyphen (-), period (.), whitespace character, or no separation at all.
